### PR TITLE
Configure Dependabot Alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# All configuration options can be referred from:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # Bundler package manager used for Gemfile
+    directory: "/" # Find Gemfile on root location
+    schedule:
+      interval: "monthly" # Get montly updates
+    labels:
+      - "dependencies" # Have label 'dependencies' for PR raised by Dependabot
+    reviewers:
+       - "leekelleher" # Ask for review of the repo owner


### PR DESCRIPTION
## Description
Added `dependabot.yml` to get dependencies updation for the repository.
Currently it is configured to get `monthly` updates from **Dependabot** for dependencies mentioned in `Gemfile` under label `dependencies`.

## Additional Context
One of the way to get dependency version updates from **Dependabot** is to configure `dependabot.yml` file. Which allows it to raise PR to keep dependencies up-to-date with new versions available.

More specific configuration can also be found at [github docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file).

This PR tries to resolve #11.